### PR TITLE
Implemented escaping for xdot special characters in symbols

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -377,7 +377,7 @@ void Parser::generateDotFile(std::string outFile)
   for(; it != this->states.end(); it++){
     for(std::pair<Symbol*, State* > t : (*it)->transitions){
       // t.first, t.second.
-      dotFile << "state" << (*it)->id << " -> state" << t.second->id << "[ penwidth = 3 fontsize = 22 fontcolor = \"black\" label = \"" << t.first->str << "\" ];\n";
+      dotFile << "state" << (*it)->id << " -> state" << t.second->id << "[ penwidth = 3 fontsize = 22 fontcolor = \"black\" label = \"" << *t.first << "\" ];\n";
     }
   }
 
@@ -442,7 +442,7 @@ void Parser::generateDotFileStep(std::string outFile, int step, int myid, bool c
   for(; it != this->states.end(); it++){
     for(std::pair<Symbol*, State* > t : (*it)->transitions){
       // t.first, t.second.
-      dotFile << "state" << (*it)->id << " -> state" << t.second->id << "[ penwidth = 3 fontsize = 22 fontcolor = \"black\" color = \"black\" label = \"" << t.first->str << "\" ];\n";
+      dotFile << "state" << (*it)->id << " -> state" << t.second->id << "[ penwidth = 3 fontsize = 22 fontcolor = \"black\" color = \"black\" label = \"" << *t.first << "\" ];\n";
     }
   }
 

--- a/src/symbol.cc
+++ b/src/symbol.cc
@@ -55,7 +55,36 @@ DollarSymbol::DollarSymbol ()
 std::ostream &operator<< (std::ostream &output, const Symbol &symbol)
 {
 //  output << "{"<<symbol.str << "," << symbol.terminal<<"}";
-  output << symbol.str;
+  char *str = symbol.str;
+  while (*str != '\0') {
+      switch (*str) {
+          case '<':
+              output << "&lt;";
+              break;
+          case '>':
+              output << "&gt;";
+              break;
+          case '&':
+              output << "&amp;";
+              break;
+          case '\\':
+              output << "\\\\";
+              break;
+          case '"':
+              output << "&quot;";
+              break;
+          case '{':
+              output << "&#123;";
+              break;
+          case '}':
+              output << "&#125;";
+              break;
+          default:
+              output << *str;
+              break;
+      }
+      str++;
+  }
   return output;
 }
 


### PR DESCRIPTION
**Issue found**: introducing some characters to grammar rules caused the program to generate invalid xdot files. The characters I identified to cause issues are `'<'`, `'>'`, `'{'`, `'}'`, `'&'`, `'\\'` and `'"'`.

**The fix**: this implementation fixes the issue by escaping them on the `<<` operator for the `Symbol` class.

**Additional changes**: a side issue found was the direct usage of the symbol's string in the `Parser::generateDotFile` function. This leads to the string not being escaped. To fix this issue, the expression `t.first->str` was replaced with `*t.first`.